### PR TITLE
Add Session Stats

### DIFF
--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -58,6 +58,10 @@ const practice = () => {
     router.push("/practice")
 }
 
+const stats = () => {
+    router.push("/stats")
+}
+
 /* MOUNT & DEMOUNT */
 onMounted(() => {
     window.addEventListener("keypress", handleKeyPresses)
@@ -122,7 +126,10 @@ const modalOpen = ref(false)
                 </div>
                 <div class="flex flex-col md:flex-row text-center justify-center">
                     <button class="text-xl md:text-2xl font-light my-4 px-8 py-2 bg-slate-100 hover:bg-slate-200 rounded-md" @click="start">start <span class="hidden md:inline-block">(space)</span></button>
-                    <button class="text-xl md:text-2xl font-light md:ml-4 my-4 px-8 py-2 bg-slate-100 hover:bg-slate-200 rounded-md" @click="practice">practice <span class="hidden md:inline-block">(p)</span></button>
+                    <div class="flex flex-row justify-between">
+                        <button class="text-xl md:text-2xl font-light md:ml-4 my-4 px-8 py-2 bg-slate-100 hover:bg-slate-200 rounded-md" @click="practice">practice <span class="hidden md:inline-block">(p)</span></button>
+                        <button class="text-xl md:text-2xl font-light md:ml-4 my-4 px-8 py-2 bg-slate-100 hover:bg-slate-200 rounded-md" @click="stats">stats</button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/pages/PlayPage.vue
+++ b/src/pages/PlayPage.vue
@@ -133,7 +133,7 @@ const focusInput = () => {
 }
 
 const pause = () => {
-    addSession(correct, missed, total, "integer", {"min": minVal.value, "max": maxVal.value}, game_start_at, new Date())
+    addSession(correct.value, missed.value, total.value, "integer", {"min": minVal.value, "max": maxVal.value}, game_start_at, new Date())
     resetScore()
     router.push("/")
 }

--- a/src/pages/PlayPage.vue
+++ b/src/pages/PlayPage.vue
@@ -37,8 +37,13 @@ const { play: playWrong } = useSound(wrongSfx)
 // score store
 import { useScoreStore } from "@/store/scoreStore"
 const scoreStore = useScoreStore()
-const { incrementCorrect, incrementMissed, reset } = scoreStore
+const { addToCorrect, addToMissed, resetScore } = scoreStore
 const { total, correct, missed } = storeToRefs(scoreStore)
+
+// stats store
+import { useStatsStore } from "@/store/statsStore"
+const statsStore = useStatsStore()
+const { addSession } = statsStore
 
 // settings store
 import { useSettingsStore } from '@/store/settingsStore';
@@ -65,10 +70,10 @@ const getRandomNumber = () => {
 const checkGuess = (guessNumber: string) => {
     if (guessNumber == currSprite.value) {
         playCorrect()
-        incrementCorrect()
+        addToCorrect(currSprite.value)
     } else {
         playWrong()
-        incrementMissed()
+        addToMissed(currSprite.value)
     }
     showAnswer()
 }
@@ -111,9 +116,11 @@ const handleShortcuts = debounce((event) => {
     }
 }, 100)
 
+const game_start_at = ref<Date>()
 const start = () => {
     currSprite.value = getRandomNumber()
     setTimeout(() => {
+        game_start_at.value = new Date()
         playNumber(currSprite.value)
         focusInput()
     }, 200)
@@ -126,6 +133,8 @@ const focusInput = () => {
 }
 
 const pause = () => {
+    addSession(correct, missed, total, "integer", {"min": minVal.value, "max": maxVal.value}, game_start_at, new Date())
+    resetScore()
     router.push("/")
 }
 
@@ -211,9 +220,9 @@ const closeModal = () => {
                     <button class="text-xl md:text-2xl font-light text-center py-4 bg-slate-100 hover:bg-slate-200 rounded-md" @click="pause">pause <span class="hidden md:inline-block">(space)</span></button>
                 </div>
                 <div class="grid grid-cols-1 md:grid-cols-3 text-xl md:text-2xl font-light text-center items-center border-t-4 pt-8">
-                    <p class="py-1 md:py-0"><span class="font-medium">correct:</span> {{ correct }} / {{ total }}</p>
-                    <p class="py-1 md:py-0"><span class="font-medium">missed:</span> {{ missed }} / {{ total }}</p>
-                    <button class="bg-slate-100 hover:bg-slate-200 rounded-md py-2 md:py-4 mt-1 md:mt-0" @click="reset">reset stats</button>
+                    <p class="py-1 md:py-0"><span class="font-medium">correct:</span> {{ correct }}</p>
+                    <p class="py-1 md:py-0"><span class="font-medium">missed:</span> {{ missed }}</p>
+                    <p class="py-1 md:py-0"><span class="font-medium">total:</span> {{ total }}</p>
                 </div>
             </div>
         </div>

--- a/src/pages/StatsPage.vue
+++ b/src/pages/StatsPage.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { storeToRefs } from "pinia";
+import { debounce } from "lodash-es"
+const route = useRoute()
+const router = useRouter()
+const num = ref()
+const childRef = ref(null)
+
+// stats store
+import { useStatsStore } from "@/store/statsStore"
+const statsStore = useStatsStore()
+const { sessions } = storeToRefs(statsStore)
+const { reset } = statsStore
+
+useHead({
+  title: route.meta.title,
+  meta: [
+    {
+      property: 'og:title',
+      content: route.meta.title,
+    },
+    {
+      name: 'twitter:title',
+      content: route.meta.title,
+    },
+  ],
+})
+
+const handleShortcuts = debounce((event) => {
+    if (event.key == "s") {
+        modalOpen.value = true
+    }
+}, 100)
+
+onMounted(() => {
+    window.addEventListener("keypress", handleShortcuts)
+})
+
+onUnmounted(() => {
+    window.removeEventListener("keypress", handleShortcuts)
+})
+
+const modalOpen = ref(false)
+
+const closeModal = () => {
+    if (modalOpen.value) {
+        modalOpen.value = false
+    }
+}
+
+</script>
+
+<template>
+    <div class="flex flex-col h-screen">
+        <PageHeader />
+		<div ref="gameArea" class="max-w-[85rem] w-full mx-auto px-4 h-full flex flex-col py-4 sm:py-10">
+            <div class="flex flex-row justify-between">
+                <h1 class="text-5xl md:text-6xl py-4">Stats</h1>
+                <div>
+                    <button class="text-xl md:text-2xl font-light md:ml-4 my-4 px-8 py-2 bg-slate-100 hover:bg-slate-200 rounded-md" @click="reset">reset</button>
+                </div>
+            </div>
+            <p class="py-2 text-xl md:text-2xl font-light">See all sessions below</p>
+            <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+                <div v-for="session of sessions" :key="session" class="rounded-md shadow-xl bg-white p-2">
+                    <p><span class="font-medium">type: </span>{{ session.type }}</p>
+                    <div class="flex flex-row">
+                        <div v-for="option in Object.keys(session.options)" :key="option" class="pr-1">
+                            <p><span class="font-medium">{{ option }}: </span>{{ session.options[option] }}</p>
+                        </div>
+                    </div>
+                    <div class="flex flex-row">
+                        <p class="pr-1"><span class="font-medium">correct: </span>{{ session.correct.length }}</p>
+                        <p class="pr-1"><span class="font-medium">missed: </span>{{ session.missed.length }}</p>
+                        <p class="pr-1"><span class="font-medium">total: </span>{{ session.total }}</p>
+                    </div>
+                    <p><span class="font-medium">date: </span>{{ new Date(session.start_at).toLocaleString('en-us', { year:"numeric", month:"short", day:"numeric", hour:"numeric", minute: "numeric" }) }}</p>
+                    <p class="pr-1"><span class="font-medium">duration: </span>{{ ((new Date(session.end_at).getTime() - new Date(session.start_at).getTime())/1000).toFixed(2)}}s</p>
+                </div>
+            </div>
+        </div>
+        <SettingsModal :is-open="modalOpen" @close="closeModal"/>
+        <PageFooter />
+    </div>
+</template>

--- a/src/pages/StatsPage.vue
+++ b/src/pages/StatsPage.vue
@@ -62,7 +62,7 @@ const closeModal = () => {
             </div>
             <p class="py-2 text-xl md:text-2xl font-light">See all sessions below</p>
             <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
-                <div v-for="session of sessions" :key="session" class="rounded-md shadow-xl bg-white p-2">
+                <div v-for="session of sessions" :key="session" class="font-light rounded-md shadow-xl bg-white p-2">
                     <p><span class="font-medium">type: </span>{{ session.type }}</p>
                     <div class="flex flex-row">
                         <div v-for="option in Object.keys(session.options)" :key="option" class="pr-1">

--- a/src/router.ts
+++ b/src/router.ts
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import HomePage from '@/pages/HomePage.vue'
 import PlayPage from '@/pages/PlayPage.vue'
 import PracticePage from '@/pages/PracticePage.vue'
+import StatsPage from '@/pages/StatsPage.vue'
 
 const routes = [
   {
@@ -25,6 +26,14 @@ const routes = [
     component: PracticePage,
     meta: {
       title: 'Practice Canto Numbers',
+    },
+  },
+  {
+    path: '/stats',
+    name: "stats",
+    component: StatsPage,
+    meta: {
+      title: 'Stats Canto Numbers',
     },
   },
 ]

--- a/src/store/scoreStore.ts
+++ b/src/store/scoreStore.ts
@@ -1,48 +1,25 @@
 import { defineStore } from 'pinia'
 
-const getSavedTotal = () => {
-    const value = localStorage.getItem("total")
-    return value ? parseInt(value) : 0
-}
-
-const getSavedCorrect = () => {
-    const value = localStorage.getItem("correct")
-    return value ? parseInt(value) : 0
-}
-
-const getSavedMissed = () => {
-    const value = localStorage.getItem("missed")
-    return value ? parseInt(value) : 0
-}
-
-
 export const useScoreStore = defineStore('score', {
     state: () => ({
-        total: getSavedTotal(),
-        correct: getSavedCorrect(),
-        missed: getSavedMissed()
+        total: 0,
+        correct: [],
+        missed: []
     }),
 
     actions: {
-        incrementCorrect() {
-            this.correct += 1
-            this.total += 1
-            localStorage.setItem("total", this.total.toString())
-            localStorage.setItem("correct", this.correct.toString())
-        },
-        incrementMissed() {
-            this.missed += 1
-            this.total += 1
-            localStorage.setItem("total", this.total.toString())
-            localStorage.setItem("missed", this.missed.toString())
-        },
-        reset() {
+        resetScore() {
             this.total = 0
-            this.correct = 0
-            this.missed = 0
-            localStorage.setItem("total", this.total.toString())
-            localStorage.setItem("correct", this.correct.toString())
-            localStorage.setItem("missed", this.missed.toString())
-        }
+            this.correct = []
+            this.missed = []
+        },
+        addToCorrect(val: string) {
+            this.correct.push(val)
+            this.total += 1
+        },
+        addToMissed(val: string) {
+            this.missed.push(val)
+            this.total += 1
+        },
     },
 })

--- a/src/store/statsStore.ts
+++ b/src/store/statsStore.ts
@@ -1,0 +1,37 @@
+import { defineStore } from 'pinia'
+
+const getSavedSessions = () => {
+    const value = localStorage.getItem("sessions")
+    return value ? JSON.parse(value) : []
+}
+
+export const useStatsStore = defineStore('stats', {
+    state: () => ({
+        sessions: getSavedSessions()
+    }),
+
+    actions: {
+        addSession(correct: Array<number>, missed: Array<number>, total: number, type: string, options: Object, start_at: Date, end_at: Date) {
+            const session = {
+                correct: correct,
+                missed: missed,
+                total: total,
+                type: type,
+                options: options,
+                start_at: start_at,
+                end_at: end_at
+            }
+            this.sessions.push(session)
+            console.log(this.sessions)
+            localStorage.setItem("sessions", JSON.stringify(this.sessions))
+        },
+        removeSessionAtIndex(index: number) {
+            this.sessions.splice(index, 1)
+            localStorage.setItem("sessions", JSON.stringify(this.sessions))
+        },
+        reset() {
+            this.sessions = []
+            localStorage.setItem("sessions", JSON.stringify(this.sessions))
+        }
+    },
+})


### PR DESCRIPTION
* Every play session is recorded and can be viewed within the `/stats` page
* A session collects the following information
  * correct: an array of the correct numbers guessed
  * missed: an array of the wrong numbers guessed
  * total: the total number of guesses made
  * type: what type of game was it (i.e. integers, time, etc.)
  * options: play options may vary between different types
  * start_at: when the session started
  * end_at: when the session ended